### PR TITLE
Fix: Configure Gradle to use Java 11 for Android build

### DIFF
--- a/medplat-android/gradle.properties
+++ b/medplat-android/gradle.properties
@@ -21,3 +21,6 @@ medplat_debug_base_url_training = http://192.168.1.12:8181/
 medplat_release_base_url = https://dpg.argusoft.com/
 medplat_release_base_url_training = https://dpg.argusoft.com/
 
+# Ensure Gradle runs with Java 11 (adjust path to your JDK installation)
+org.gradle.java.home=C:/Program Files/Java/jdk-11.0.20
+


### PR DESCRIPTION
## Summary
The Android Gradle plugin requires Java 11+. This change ensures the `medplat-android` build uses Java 11 by adding an explicit Gradle Java home configuration.

## Changes
- Updated `medplat-android/gradle.properties`:
  - Added `org.gradle.java.home=C:/Program Files/Java/jdk-11.0.20`

## Why
When Gradle runs with Java 8 the Android plugin fails during project evaluation:
`Android Gradle plugin requires Java 11 to run. You are currently using Java 1.8.`  
This prevents the `medplat-android` module from building. Adding `org.gradle.java.home` points Gradle at a Java 11 installation so the Android build can run in CI or locally without JVM mismatch issues.

## Testing
1. Ensure JDK 11 is installed on your machine (or CI image).
2. From repo root run:
(On Windows: `gradlew.bat assembleDebug`)
3. Build should start and proceed past project evaluation (no Java 11 error).

## Notes & Compatibility
- The `org.gradle.java.home` path is an environment-specific pointer. Please adjust the path to match the JDK location on your machine/CI.
- Alternatively, users may set `JAVA_HOME` to a JDK 11+ installation instead of relying on this property.
- This change is non-breaking for other modules (`medplat-web`, `medplat-ui`) which are unaffected.

## Follow-up
- If maintainers prefer not to hardcode a machine-specific path, we can remove this change and instead update the repo README/CI config to require JDK 11 or set `org.gradle.java.home` in CI.